### PR TITLE
build: android support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,11 +1,8 @@
 VPATH=%VPATH%
 
-CC ?= gcc
-CXX ?= g++
-CXXFLAGS ?=
-AR ?= ar
-RUSTC ?= rustc
-RUSTFLAGS ?=
+ifeq ($(CFG_OSTYPE),linux-androideabi)
+    RUSTFLAGS += -L./../fontconfig/src/.libs
+endif
 
 RUST_SRC=$(shell find $(VPATH)/. -type f -name '*.rs')
 

--- a/configure
+++ b/configure
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 SRCDIR="$(cd $(dirname $0) && pwd)"
-sed "s#%VPATH%#${SRCDIR}#" ${SRCDIR}/Makefile.in > Makefile
-
+sed -e "s#%VPATH%#${SRCDIR}#" ${SRCDIR}/Makefile.in > Makefile


### PR DESCRIPTION
android port preparation
1. additional submodule required for android
   fontconfig, libexpat, libfreetype2
2. It might need to update submodule and servo at once 
