### PR TITLE
support android build

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -7,6 +7,10 @@ AR ?= ar
 RUSTC ?= rustc
 RUSTFLAGS ?=
 
+ifeq ($(CFG_OSTYPE),linux-androideabi)
+RUSTFLAGS += -L./../../android/fontconfig/src/.libs
+endif
+
 RUST_SRC=$(shell find $(VPATH)/. -type f -name '*.rs')
 
 .PHONY: all

--- a/fontconfig.rc
+++ b/fontconfig.rc
@@ -17,5 +17,6 @@ pub mod fontconfig;
 
 #[nolink]
 #[cfg(target_os = "linux")]
+#[cfg(target_os = "android")]
 #[link_args = "-lfontconfig"]
 extern { }


### PR DESCRIPTION
Support android build
This commit does not affect to each submodule's original standalone build system.
