### PR TITLE
Allow non-camel-case types in bindings

### DIFF
--- a/fontconfig.rs
+++ b/fontconfig.rs
@@ -8,6 +8,7 @@
 // except according to those terms.
 
 #![allow(non_uppercase_statics)]
+#![allow(non_camel_case_types)]
 
 use libc::*;
 


### PR DESCRIPTION
Just cleaning up warnings.
