### PR TITLE
Add a dependency on fontconfig so that the static lib is included

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,5 +13,6 @@
 #![crate_type = "rlib"]
 
 extern crate libc;
+extern crate fontconfig_sys;
 
 pub mod fontconfig;


### PR DESCRIPTION
r? @metajack @mbrubeck 

CC @alexcrichton

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-fontconfig/29)
<!-- Reviewable:end -->
